### PR TITLE
Simple fix 404 link to contribute page

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The next time you want to execute Tideflow locally, simply run `meteor`
 ## Contributing
 
 If you would like to contribute to Tideflow, check out the
-[Contributing Guide](https://tideflow.io/docs/contribute).
+[Contributing Guide](https://docs.tideflow.io/docs/contribute).
 
 ## License
 


### PR DESCRIPTION
https://tideflow.io/docs/contribute resolves as a 404, later link https://docs.tideflow.io/docs/contribute is live.
Updated that link in ## Contributing